### PR TITLE
Make the extensions work with an italian keyboard

### DIFF
--- a/keypress.js
+++ b/keypress.js
@@ -12,7 +12,7 @@
 
 
 		this.keyPressHandler = function(e) {
-			if ( e.keyCode == hotkey && (!e.shiftKey && !e.metaKey && !e.altKey && !e.ctrlKey) ) {
+			if ( e.keyCode == hotkey && (!e.metaKey && !e.altKey && !e.ctrlKey) ) {
 				var popover = document.getElementsByClassName("NB-popover"); // Ignore if popup to add a new feed is visible
 				elems = document.getElementsByClassName("NB-story-title NB-selected");
 				if ( (popover.length == 0) && elems.length) {


### PR DESCRIPTION
When using a keyboard with the italian layout you need to press shift + "," for a ";". With "!e.shiftKey && " in the if the key press event was ignored.
