### PR TITLE
Adds matches for bare (non-www) Newsblur URLs.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
    },
    "content_scripts": [ {
       "js": [ "keypress.js" ],
-      "matches": [ "http://www.newsblur.com/*", "https://www.newsblur.com/*" ]
+      "matches": [ "http://www.newsblur.com/*", "https://www.newsblur.com/*", "http://newsblur.com/*", "https://newsblur.com/*" ]
    } ],
   "name": "Background Tab for NewsBlur",
   "icons": { "16": "icon16.png",


### PR DESCRIPTION
Newsblur doesn't redirect www and the bare domain to the same URL, so the matching needed to be expanded.

I'm not sure if permissions should include all four patterns or not so I left it as-is.

I was tempted to replace the match patterns with `*://*.newsblur.com/*` or at least `http://*.newsblur.com/*` and `https://*.newsblur.com/*` which would enable it on the `dev.newsblur.com` version of the site also but I was afraid it might interfere with parts of Newsblur I'm not that familiar with (such as individual blurblogs).