### PR TITLE
Opens new tabs next to the current NewsBlur tab.

### DIFF
--- a/listener.js
+++ b/listener.js
@@ -1,5 +1,5 @@
 /**
- * 
+ *
 
  @author Darryl Tam
 
@@ -19,14 +19,22 @@ This file is part of Background Tab for NewsBlur.
 
     You should have received a copy of the GNU General Public License
     along with Background Tab for NewsBlur.  If not, see <http://www.gnu.org/licenses/>.
- 
+
  */
 
 /**
  * This will open up a new background tab with the url passed
  */
 chrome.extension.onMessage.addListener(
-  function(itemURL) {
-		chrome.tabs.create({ url: itemURL.url, active: false });
-	}
+  function(message) {
+    chrome.tabs.query({ active: true },
+      function(current_tab) {
+        var options = { url: message.url, active: false };
+        if (current_tab && current_tab[0] && current_tab[0].index) {
+          options['index'] = current_tab[0].index + 1;
+        }
+        chrome.tabs.create(options);
+      }
+    );
+  }
 );

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
            "64": "icon64.png",
           "128": "icon128.png" },
   "version": "0.2",
-  "permissions": [ "http://www.newsblur.com/*"],
+  "permissions": [ "http://www.newsblur.com/*", "https://www.newsblur.com/*" ],
   "description": "Opens the active item in a background tab when the user presses ';' in NewsBlur",
   "manifest_version": 2
 }


### PR DESCRIPTION
Instead of appending them at the end of all tabs.