### PR TITLE
Migrate chrome.extension to chrome.runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 BackgroundTab for NewsBlur
 ==========================
 
-_Note from jscher2000: This is a port for Firefox with extremely minimal changes just to get the hotkeys to work. It is not yet published to AMO. You can download the zip file, unarchive it, and use about:debugging to load it as a temporary extension. Please files issues for problems you notice. And now back to the original author's README._
-
 Now licensed under GPL Version 3 and available in the Chrome Web Store:
 https://chrome.google.com/webstore/detail/background-tab-for-newsbl/ieeimmkgocgaaabphkgjdkophaejfnlk/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 BackgroundTab for NewsBlur
 ==========================
 
+_Note from jscher2000: This is a port for Firefox with extremely minimal changes just to get the hotkeys to work. It is not yet published to AMO. You can download the zip file, unarchive it, and use about:debugging to load it as a temporary extension. Please files issues for problems you notice. And now back to the original author's README._
+
 Now licensed under GPL Version 3 and available in the Chrome Web Store:
 https://chrome.google.com/webstore/detail/background-tab-for-newsbl/ieeimmkgocgaaabphkgjdkophaejfnlk/
 

--- a/keypress.js
+++ b/keypress.js
@@ -46,7 +46,7 @@ This file is part of Background Tab for NewsBlur.
 					if (elems2.length) {
 						e.preventDefault();
 						e.stopImmediatePropagation();
-						chrome.extension.sendMessage({url: elems2.item(0).href});
+						browser.runtime.sendMessage({url: elems2.item(0).href});
 					}
 				}
 		

--- a/keypress.js
+++ b/keypress.js
@@ -46,7 +46,8 @@ This file is part of Background Tab for NewsBlur.
 					if (elems2.length) {
 						e.preventDefault();
 						e.stopImmediatePropagation();
-						browser.runtime.sendMessage({url: elems2.item(0).href});
+						console.log('Sending URL: ' + elems2.item(0).href);
+						chrome.runtime.sendMessage({url: elems2.item(0).href});
 					}
 				}
 		

--- a/keypress.js
+++ b/keypress.js
@@ -46,7 +46,6 @@ This file is part of Background Tab for NewsBlur.
 					if (elems2.length) {
 						e.preventDefault();
 						e.stopImmediatePropagation();
-						console.log('Sending URL: ' + elems2.item(0).href);
 						chrome.runtime.sendMessage({url: elems2.item(0).href});
 					}
 				}

--- a/listener.js
+++ b/listener.js
@@ -25,7 +25,7 @@ This file is part of Background Tab for NewsBlur.
 /**
  * This will open up a new background tab with the url passed
  */
-chrome.extension.onMessage.addListener(
+browser.runtime.onMessage.addListener(
   function(message) {
     chrome.tabs.query({ active: true, currentWindow: true },
       function(current_tab) {

--- a/listener.js
+++ b/listener.js
@@ -25,7 +25,7 @@ This file is part of Background Tab for NewsBlur.
 /**
  * This will open up a new background tab with the url passed
  */
-browser.runtime.onMessage.addListener(
+chrome.runtime.onMessage.addListener(
   function(message) {
     chrome.tabs.query({ active: true, currentWindow: true },
       function(current_tab) {


### PR DESCRIPTION
chrome.extension.onMessage and chrome.extension.sendMessage were deprecated in Chrome 33. Migrating to chrome.runtime.onMessage and chrome.runtime.sendMessage is needed for Firefox compatibility. 